### PR TITLE
Added Build War Filename as ClinicJavaWebEE

### DIFF
--- a/ClinicJavaWebEE/pom.xml
+++ b/ClinicJavaWebEE/pom.xml
@@ -113,6 +113,7 @@
 
 
 	<build>
+	<finalName>ClinicJavaWebEE</finalName>
 		<plugins>
 			<plugin>
 				<artifactId>maven-compiler-plugin</artifactId>


### PR DESCRIPTION
Added Final Build War file name as ClinicJavaWebEE so that deployed website uses this filename as root without including version